### PR TITLE
[polybar] add battery to ble icon

### DIFF
--- a/polybar/scripts/bluetooth_headphones_status.sh
+++ b/polybar/scripts/bluetooth_headphones_status.sh
@@ -2,6 +2,7 @@
 DIR=$(dirname $0)
 CMD=$1
 
+
 # Get the first bluetooth device info
 # This comes as a CSV
 BT_SINK=$(pacmd list-cards | $DIR/bt_dev_info.awk | grep "bluez" | head -n 1)
@@ -25,12 +26,21 @@ if [ ! -z ${BT_SINK} ]; then
       next_profile=""
       ;;
   esac
+
+  # Read battery as a percentage, upower needs to be installed and
+  # experimental bluetooth features need to be enabled, see
+  # https://wiki.archlinux.org/title/bluetooth#Enabling_experimental_features
+  mac_address=$(echo ${BT_SINK} | cut -d "," -f 5)
+  battery=$(upower -d | $DIR/read_battery.awk | grep ${mac_address} | head -n 1 | cut -d "," -f 3)
+
   case $CMD in
     "toggle_profile")
       pacmd set-card-profile ${id} ${next_profile}
       ;;
     *)
-      echo "${icon} "
+      icon+=" "
+      [ ! -z "$battery" ] && icon+=" ~ ${battery} 🔋"
+      echo "${icon}"
       ;;
   esac
 else

--- a/polybar/scripts/bt_dev_info.awk
+++ b/polybar/scripts/bt_dev_info.awk
@@ -1,16 +1,18 @@
 #!/bin/awk -f
 BEGIN {
   FS = "([ ]?:[ ])|([ ]=[ ])";
-  print "INDEX,NICE_NAME,DEVICE,ACTIVE_PROFILE"
+  print "INDEX,NICE_NAME,DEVICE,ACTIVE_PROFILE,MAC"
   count = 0;
 }
 /index/ { i=$2; indices[count++] = $2 }
 /^\s+name:/ { names[i] = $2 }
 /^\s+active profile:/ { profiles[i] = $2 }
 /^\s+device\.description/ { nice[i] = $2 }
+/^\s+device\.string/ { gsub(/"/,"",$2); mac[i] = $2; }
 END {
   for (j=0; j<count; j++) {
     i=indices[j];
-    print i "," nice[i] "," names[i] "," profiles[i]
+    print i "," nice[i] "," names[i] "," profiles[i] "," mac[i]
   }
 }
+

--- a/polybar/scripts/read_battery.awk
+++ b/polybar/scripts/read_battery.awk
@@ -1,0 +1,13 @@
+#!/bin/awk -f
+BEGIN {
+  FS = "([ ]?:[ ]+)";
+  print "DEVICE,SERIAL,BATTERY_LVL";
+}
+/^Device/ { current_dev=$2; }
+/^\s+serial/{ serial[current_dev]=$2; }
+/^\s+percentage/{ batteries[current_dev]=$2; }
+END {
+    for(device in batteries){
+        print device "," serial[device] "," batteries[device];
+    }
+}


### PR DESCRIPTION
This commit amends the polybar scripts to add the remaining battery of the connected bluetooth device if present.

The feature requires to have the bluetooth experimental features [enabled] (https://wiki.archlinux.org/title/bluetooth#Enabling_experimental_features) and [upower](https://upower.freedesktop.org/) installed.